### PR TITLE
Manage Class Sub-Pages

### DIFF
--- a/src/Kambaz/Courses/Piazza/ManageClass/CreateGroups.tsx
+++ b/src/Kambaz/Courses/Piazza/ManageClass/CreateGroups.tsx
@@ -1,0 +1,14 @@
+export default function CreateGroups() {
+  return (
+    <div id="create_groups" className="d-flex flex-column gap-3">
+      <hr style={{ border: "3px solid black" }} />
+
+      {/* Header */}
+      <div className="d-flex flex-column">
+        <h2 className="fw-bold">Enable Group Based Discussion</h2>
+        <hr />
+        <p>Create groups to reflect the section or team names for your class.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/Kambaz/Courses/Piazza/ManageClass/CustomizeCoursePage.tsx
+++ b/src/Kambaz/Courses/Piazza/ManageClass/CustomizeCoursePage.tsx
@@ -1,0 +1,16 @@
+export default function CustomizeCoursePage() {
+  return (
+    <div id="customize_course_page" className="d-flex flex-column gap-3">
+      <hr style={{ border: "3px solid black" }} />
+
+      {/* Header */}
+      <div className="d-flex flex-column">
+        <h2 className="fw-bold">Course Page Settings</h2>
+        <hr />
+        <p>Decide how many resources to display within a section at a time.</p>
+
+        <p>Control access to the sections of your course page by selecting which will be public.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/Kambaz/Courses/Piazza/ManageClass/CustomizeQA.tsx
+++ b/src/Kambaz/Courses/Piazza/ManageClass/CustomizeQA.tsx
@@ -1,0 +1,14 @@
+export default function CustomizeQA() {
+  return (
+    <div id="customize_qa" className="d-flex flex-column gap-3">
+      <hr style={{ border: "3px solid black" }} />
+
+      {/* Header */}
+      <div className="d-flex flex-column">
+        <h2 className="fw-bold">Q&A Settings</h2>
+        <hr />
+        <p>Fine tune your class Q&A by enabling private or anonymous posts.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/Kambaz/Courses/Piazza/ManageClass/GeneralSettings.tsx
+++ b/src/Kambaz/Courses/Piazza/ManageClass/GeneralSettings.tsx
@@ -1,0 +1,20 @@
+export default function GeneralSettings() {
+  return (
+    <div id="general_settings" className="d-flex flex-column gap-3">
+      <hr style={{ border: "3px solid black" }} />
+
+      {/* Header */}
+      <div className="d-flex flex-column">
+        <h2 className="fw-bold">General Settings</h2>
+        <hr />
+        <p>Edit your course number & name.</p>
+
+        <p>Access your course signup & direct links.</p>
+
+        <p>Control whether instructors can enroll themselves in the course.</p>
+
+        <p>Need to pause the course for a take-home exam? Make the class inactive.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/Kambaz/Courses/Piazza/ManageClass/ManageClass.tsx
+++ b/src/Kambaz/Courses/Piazza/ManageClass/ManageClass.tsx
@@ -2,6 +2,12 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import ManageClassTab from "./ManageClassTab";
 import ManageFolders from "./ManageFolders";
 import "./ManageClass.css";
+import GeneralSettings from "./GeneralSettings";
+import CustomizeQA from "./CustomizeQA";
+import ManageEnrollment from "./ManageEnrollment";
+import CreateGroups from "./CreateGroups";
+import CustomizeCoursePage from "./CustomizeCoursePage";
+import PiazzaNetworkSettings from "./PiazzaNetworkSettings";
 
 export default function ManageClassScreen() {
   return (
@@ -11,7 +17,13 @@ export default function ManageClassScreen() {
       <div>
         <Routes>
           <Route path="/" element={<Navigate to="Manage-Folders" />} />
+          <Route path="/General-Settings/*" element={<GeneralSettings />} />
+          <Route path="/Customize-Q&A/*" element={<CustomizeQA />} />
           <Route path="/Manage-Folders/*" element={<ManageFolders />} />
+          <Route path="/Manage-Enrollment/*" element={<ManageEnrollment />} />
+          <Route path="/Create-Groups/*" element={<CreateGroups />} />
+          <Route path="/Customize-Course-Page/*" element={<CustomizeCoursePage />} />
+          <Route path="/Piazza-Network-Settings/*" element={<PiazzaNetworkSettings />} />
         </Routes>
       </div>
     </div >

--- a/src/Kambaz/Courses/Piazza/ManageClass/ManageEnrollment.tsx
+++ b/src/Kambaz/Courses/Piazza/ManageClass/ManageEnrollment.tsx
@@ -1,0 +1,14 @@
+export default function ManageEnrollment() {
+  return (
+    <div id="manage_enrollment" className="d-flex flex-column gap-3">
+      <hr style={{ border: "3px solid black" }} />
+
+      {/* Header */}
+      <div className="d-flex flex-column">
+        <h2 className="fw-bold">Enroll Professors/TAs</h2>
+        <hr />
+        <p>Make sure all instructors are enrolled in the course. The more folks you have responding to student questions, the better!</p>
+      </div>
+    </div>
+  );
+}

--- a/src/Kambaz/Courses/Piazza/ManageClass/PiazzaNetworkSettings.tsx
+++ b/src/Kambaz/Courses/Piazza/ManageClass/PiazzaNetworkSettings.tsx
@@ -1,0 +1,14 @@
+export default function PiazzaNetworkSettings() {
+  return (
+    <div id="piazza_network_settings" className="d-flex flex-column gap-3">
+      <hr style={{ border: "3px solid black" }} />
+
+      {/* Header */}
+      <div className="d-flex flex-column">
+        <h2 className="fw-bold">Piazza Network Settings</h2>
+        <hr />
+        <p>Configure Piazza Network settings for your class to best match what your students need.</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR includes the additional pages from the Manage Class page on Piazza. These are meant to be stubs since we are not required to implement any functionality other than managing folders. Once the logic for hiding the posts on clicking the Manage Class button is implemented, this will look better taking up the whole screen.

A QOL change I made was to implement all the pages as their own links and not in one long page like Piazza does.

UI-wise, we are good! For the future, we will have to think about how to implement editing the folder names and deleting folders.


https://github.com/user-attachments/assets/32eaedc9-5258-4078-8d52-704c7332b881