### PR TITLE
Delete and Edit Endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -553,6 +553,30 @@ app.delete('/api/reply/:rid', async (req, res) => {
     }
 });
 
+// update a reply's content 
+app.put('/api/reply/updateReply', async (req, res) => {
+    try {
+        // reply id is a request parameter 
+        const { rid, newContent } = req.body;
+
+        // ensure that the id is a valid id
+        if (!mongoDB.ObjectId.isValid(rid)) {
+            res.status(400).send('Invalid ID format');
+            return;
+        }
+
+        const updatedReply = await replies.findOneAndUpdate(
+            { _id: new ObjectId(rid) },
+            { $set: { content: newContent } },
+            { returnDocument: "after" }
+        );
+
+        res.json(updatedReply);
+    } catch (err) {
+        res.status(500).send(`Error when updating reply: ${err}`);
+    }
+});
+
 // app.listen(3000, 'localhost', () => {
 //     console.log('Server running on Port 3000');
 // });

--- a/server.js
+++ b/server.js
@@ -326,6 +326,30 @@ app.delete('/api/followupDiscussion/:fudId', async (req, res) => {
     }
 });
 
+// update a followup discussion's content 
+app.put('/api/followupDiscussion/updateFud', async (req, res) => {
+    try {
+        // fud id is a request parameter 
+        const { fudId, newContent } = req.body;
+
+        // ensure that the id is a valid id
+        if (!mongoDB.ObjectId.isValid(fudId)) {
+            res.status(400).send('Invalid ID format');
+            return;
+        }
+
+        const updatedFud = await followupDiscussions.findOneAndUpdate(
+            { _id: new ObjectId(fudId) },
+            { $set: { content: newContent } },
+            { returnDocument: "after" }
+        );
+
+        res.json(updatedFud);
+    } catch (err) {
+        res.status(500).send(`Error when updating fud: ${err}`);
+    }
+});
+
 // add a followup discussion to post 
 app.put('/api/post/addDiscussion', async (req, res) => {
     try {

--- a/server.js
+++ b/server.js
@@ -350,6 +350,34 @@ app.put('/api/followupDiscussion/updateFud', async (req, res) => {
     }
 });
 
+// remove a reply from a followup discussion - called when deleting a reply
+app.put('/api/followupDiscussion/removeReply', async (req, res) => {
+    try {
+        const { fudId, replyId } = req.body;
+        // ensure that the id is a valid id
+        if (!mongoDB.ObjectId.isValid(fudId) || !mongoDB.ObjectId.isValid(replyId)) {
+            res.status(400).send('Invalid ID format');
+            return;
+        }
+
+        const updatedFud = await followupDiscussions.findOneAndUpdate(
+            {
+                _id: new ObjectId(fudId),
+            },
+            {
+                $pull: {
+                    replies: replyId, // remove replyId from the array
+                },
+            },
+            { returnDocument: "after" }
+        );
+
+        res.json(updatedFud);
+    } catch (err) {
+        res.status(500).send(`Error when removing reply from fud: ${err}`);
+    }
+});
+
 // add a followup discussion to post 
 app.put('/api/post/addDiscussion', async (req, res) => {
     try {

--- a/server.js
+++ b/server.js
@@ -35,11 +35,6 @@ const followupDiscussions = db.collection("followupDiscussions");
 const replies = db.collection("replies");
 const folders = db.collection("folders");
 
-
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
-
-const postsFilePath = '/Users/katiewinkleblack/Desktop/2025/WEBDEV_NEW/PazzaProject/ACTUAL/pazza-react-web-app/src/Kambaz/Database/posts.json';
-
 // create a new post 
 app.post('/api/post/createPost', async (req, res) => {
     if (!(req.body.folders !== undefined &&
@@ -71,9 +66,7 @@ app.post('/api/post/createPost', async (req, res) => {
     const newPost = req.body;
     try {
         const result = await posts.insertOne(newPost);
-        console.log('result: ', result);
         const createdPost = await posts.findOne({ _id: result.insertedId });
-        console.log('created post: ', createdPost)
         res.json(createdPost);
     } catch (err) {
         res.status(500).send(`Error when creating post: ${err}`);

--- a/server.js
+++ b/server.js
@@ -39,29 +39,45 @@ const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 const postsFilePath = '/Users/katiewinkleblack/Desktop/2025/WEBDEV_NEW/PazzaProject/ACTUAL/pazza-react-web-app/src/Kambaz/Database/posts.json';
 
+// create a new post 
+app.post('/api/post/createPost', async (req, res) => {
+    if (!(req.body.folders !== undefined &&
+        req.body.folders.length !== 0 && // folders should be defined and at least one folder should be selected
+        req.body.authorId !== undefined &&
+        req.body.authorId !== '' &&
+        req.body.datePosted !== undefined &&
+        req.body.datePosted !== '' &&
+        req.body.type !== undefined &&
+        req.body.instructor !== undefined &&
+        req.body.title !== undefined &&
+        req.body.title !== '' &&
+        req.body.content !== undefined &&
+        req.body.content !== '' &&
+        req.body.followupDiscussions !== undefined &&
+        req.body.followupDiscussions.length === 0 && // should be no fuds initially 
+        req.body.studentAnswer !== undefined &&
+        req.body.studentAnswer === null &&
+        req.body.instructorAnswer !== undefined &&
+        req.body.instructorAnswer === null &&
+        req.body.viewers !== undefined &&
+        req.body.viewers.length === 0 && // no viewers upon creation 
+        req.body.courseId !== undefined &&
+        req.body.courseId !== '')) {
+        res.status(400).send('Invalid post body');
+        return;
+    }
 
-app.post('/api/post', (req, res) => {
-    console.log("received body");
-    console.log(postsFilePath);
     const newPost = req.body;
-
-    fs.readFile(postsFilePath, "utf-8", (err, data) => {
-        if (err) {
-            return res.status(500).send('Error reading posts');
-        }
-
-        const posts = JSON.parse(data || '[]');
-        posts.push(newPost);
-
-        fs.writeFile(postsFilePath, JSON.stringify(posts, null, 2), (err) => {
-            if (err) {
-                return res.status(500).send('Error saving post');
-            }
-            res.status(201).send('Post added successfully');
-        });
-    });
-
-});
+    try {
+        const result = await posts.insertOne(newPost);
+        console.log('result: ', result);
+        const createdPost = await posts.findOne({ _id: result.insertedId });
+        console.log('created post: ', createdPost)
+        res.json(createdPost);
+    } catch (err) {
+        res.status(500).send(`Error when creating post: ${err}`);
+    }
+})
 
 // get all posts in database
 app.get('/api/post/posts', async (req, res) => {

--- a/src/Kambaz/Courses/Piazza/NewPost.tsx
+++ b/src/Kambaz/Courses/Piazza/NewPost.tsx
@@ -9,6 +9,7 @@ import { folders } from "../../Database";
 import "./../../styles.css";
 import { createPost } from "./services/postService";
 import { Post } from "../../types";
+import { usePostSidebarContext } from "./hooks/usePostSidebarContext";
 
 export default function NewPostPage() {
    const [selectedOption, setSelectedOption] = useState<string>('');
@@ -19,7 +20,7 @@ export default function NewPostPage() {
 
    const navigate = useNavigate();
    const { cid } = useParams();
-
+   const { fetchPosts } = usePostSidebarContext();
 
    const DeleteButton = () => {
       navigate(`/Kambaz/Courses/${cid}/Piazza/`);
@@ -97,6 +98,7 @@ export default function NewPostPage() {
 
             if (newPostFromDb && newPostFromDb._id) {
                navigate(`/Kambaz/Courses/${cid}/Piazza`);
+               await fetchPosts();
             }
             else {
                console.error("Failed to Post");

--- a/src/Kambaz/Courses/Piazza/NewPost.tsx
+++ b/src/Kambaz/Courses/Piazza/NewPost.tsx
@@ -7,13 +7,15 @@ import { useNavigate } from "react-router-dom";
 import { useParams } from "react-router";
 import { folders } from "../../Database";
 import "./../../styles.css";
+import { createPost } from "./services/postService";
+import { Post } from "../../types";
 
 export default function NewPostPage() {
    const [selectedOption, setSelectedOption] = useState<string>('');
    const [selectedPostTo, setSelectedPostTo] = useState<string>('');
    const [selectedFolders, setSelectedFolders] = useState<string[]>([]);
    const [editorValue, setEditorValue] = useState("");
-   const [postSumary, setPostSummary] = useState("");
+   const [postSummary, setPostSummary] = useState("");
 
    const navigate = useNavigate();
    const { cid } = useParams();
@@ -41,10 +43,8 @@ export default function NewPostPage() {
       setEditorValue(value);
    };
 
-
    const handleFolderChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const { value, checked } = event.target;
-
 
       if (checked) {
          setSelectedFolders((prev) => [...prev, value]);
@@ -56,7 +56,7 @@ export default function NewPostPage() {
 
    const postButton = async () => {
       if (!selectedOption) {
-         alert("Please choose a post yype: Question/Note");
+         alert("Please choose a post type: Question/Note");
          return;
       }
       if (!selectedPostTo) {
@@ -67,7 +67,7 @@ export default function NewPostPage() {
          alert("Please choose a folder(s)");
          return;
       }
-      if (!postSumary) {
+      if (!postSummary) {
          alert("Please put a summary for your post");
          return;
       }
@@ -76,41 +76,34 @@ export default function NewPostPage() {
          return;
       }
 
-      const newPost = {
-         _id: `P${Date.now()}`,
-         folderId: selectedFolders.join(','),
-         authorId: 'user123',
-         datePosted: new Date().toISOString(),
-         type: 2,
-         instructor: 1,
-         title: postSumary,
-         content: editorValue,
-         followUpQuestions: '',
-         studentAnswer: '',
-         instructorAnswer: '',
-         viewers: '',
-         courseId: cid,
-      };
+      if (cid) {
+         const newPost: Post = {
+            folders: selectedFolders,
+            authorId: 'user123', // TODO - update to be logged in user
+            datePosted: new Date().toISOString(),
+            type: selectedOption === 'question' ? 0 : 1, // 0 for question, 1 for note
+            instructor: false, // TODO - need to determine if author is an instructor (i.e. logged in user is instructor)
+            title: postSummary,
+            content: editorValue,
+            followupDiscussions: [],
+            studentAnswer: null,
+            instructorAnswer: null,
+            viewers: [],
+            courseId: cid,
+         };
 
-      try {
+         try {
+            const newPostFromDb = await createPost(newPost);
 
-         const response = await fetch("http://localhost:3000/api/post", {
-            method: "POST",
-            headers: {
-               "Content-Type": "application/json",
-            },
-            body: JSON.stringify(newPost),
-         });
-
-         if (response.ok) {
-            console.log("New Post Added");
-            navigate(`/Kambaz/Courses/${cid}/Piazza`);
+            if (newPostFromDb && newPostFromDb._id) {
+               navigate(`/Kambaz/Courses/${cid}/Piazza`);
+            }
+            else {
+               console.error("Failed to Post");
+            }
+         } catch (error) {
+            console.error("Error creating post: ", error);
          }
-         else {
-            console.error("Failed to Post");
-         }
-      } catch (error) {
-         console.error("Server Error Katie:", error);
       }
    };
 
@@ -121,7 +114,7 @@ export default function NewPostPage() {
          <div className="">
             <div>
                <div id="wd-class-stats" className="d-flex wd-text-grey wd-font-bold"
-                  style={{ fontSize: "14px", flex: '0 0 20%', paddingLeft: "20px"}}>
+                  style={{ fontSize: "14px", flex: '0 0 20%', paddingLeft: "20px" }}>
                   Post Type*
                   <div id="">
                      <div className="">
@@ -283,7 +276,7 @@ export default function NewPostPage() {
                               <Form.Control id="wd-name" type="text"
                                  placeholder="Enter a one line summary here, 100 characters or less"
                                  style={{ fontSize: "13px" }}
-                                 value={postSumary}
+                                 value={postSummary}
                                  onChange={handleSummaryChange}
                               />
                            </Col>
@@ -316,8 +309,6 @@ export default function NewPostPage() {
 
                         <span className="wd-rotated-asterick">*</span>Required fields
 
-
-
                      </div>
 
                      <div className="d-flex">
@@ -343,9 +334,7 @@ export default function NewPostPage() {
                </div>
             </div>
          </div>
-         {/* </div> */}
       </div>
-
 
    );
 }

--- a/src/Kambaz/Courses/Piazza/ViewPost/ActionsDropdown.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/ActionsDropdown.tsx
@@ -1,0 +1,42 @@
+interface ActionsDropdownProps {
+    showDropdown: boolean;
+    setShowDropdown: (newShowDropdown: boolean) => void;
+    setIsEditing: (newIsEditing: boolean) => void;
+    handleDelete: () => void;
+}
+
+// TODO - only creator and instructors should be allowed to edit/delete an element 
+// dropdown component for editing and deleting; used for answers, followup discussions, and replies
+export default function ActionsDropdown(props: ActionsDropdownProps) {
+    const { showDropdown, setShowDropdown, setIsEditing, handleDelete } = props;
+
+    return (
+        <div className="float-end dropdown">
+            {/* actions dropdown for edit and delete */}
+            <button
+                aria-haspopup="true"
+                aria-expanded={showDropdown}
+                data-id="postActionMenuId"
+                type="button"
+                className="dropdown-toggle btn btn-action"
+                onClick={() => setShowDropdown(!showDropdown)}
+            >Actions</button>
+            {showDropdown && (
+                <ul className="dropdown-menu show position-absolute">
+                    <li>
+                        <button className="dropdown-item" onClick={() => setIsEditing(true)}>
+                            Edit
+                        </button>
+                    </li>
+                    <li>
+                        <button className="dropdown-item text-danger"
+                            onClick={handleDelete}
+                        >
+                            Delete
+                        </button>
+                    </li>
+                </ul>
+            )}
+        </div>
+    )
+}

--- a/src/Kambaz/Courses/Piazza/ViewPost/ActionsDropdown.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/ActionsDropdown.tsx
@@ -12,13 +12,12 @@ export default function ActionsDropdown(props: ActionsDropdownProps) {
 
     return (
         <div className="float-end dropdown">
-            {/* actions dropdown for edit and delete */}
             <button
                 aria-haspopup="true"
                 aria-expanded={showDropdown}
                 data-id="postActionMenuId"
                 type="button"
-                className="dropdown-toggle btn btn-action"
+                className="dropdown-toggle btn"
                 onClick={() => setShowDropdown(!showDropdown)}
             >Actions</button>
             {showDropdown && (

--- a/src/Kambaz/Courses/Piazza/ViewPost/Answer.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/Answer.tsx
@@ -1,5 +1,5 @@
 import { type Answer } from "../../../types";
-import WipAnswer from "./WipAnswer";
+import EditingAnswer from "./EditingAnswer";
 import useAnswer from "../hooks/useAnswer";
 import ActionsDropdown from "./ActionsDropdown";
 
@@ -29,7 +29,7 @@ export default function Answer(props: AnswerProps) {
     return (
         <div>
             {isEditing ? (
-                <WipAnswer
+                <EditingAnswer
                     initialAnswer={answer ? answer.content : ""} // TODO improve this check 
                     onSave={handleOnSave}
                     onCancel={() => { setIsEditing(false); setShowDropdown(false); }}

--- a/src/Kambaz/Courses/Piazza/ViewPost/Answer.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/Answer.tsx
@@ -5,12 +5,13 @@ import useAnswer from "../hooks/useAnswer";
 interface AnswerProps {
     answerId: string;
     type: string;
+    setPost: (post: any) => void;
 }
 
 // Component for displaying an answer to a post.
 export default function Answer(props: AnswerProps) {
 
-    const { answerId, type } = props;
+    const { answerId, type, setPost } = props;
 
     const {
         isEditing,
@@ -21,7 +22,8 @@ export default function Answer(props: AnswerProps) {
         setShowDropdown,
         formatAnswerDate,
         authors,
-    } = useAnswer(answerId);
+        handleDelete
+    } = useAnswer(answerId, type, setPost);
 
     return (
         <div>
@@ -68,7 +70,7 @@ export default function Answer(props: AnswerProps) {
                                             </li>
                                             <li>
                                                 <button className="dropdown-item text-danger"
-                                                // onClick={handleDelete}
+                                                onClick={handleDelete}
                                                 >
                                                     Delete
                                                 </button>

--- a/src/Kambaz/Courses/Piazza/ViewPost/Answer.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/Answer.tsx
@@ -31,7 +31,7 @@ export default function Answer(props: AnswerProps) {
                 <WipAnswer
                     initialAnswer={answer ? answer.content : ""} // TODO improve this check 
                     onSave={handleOnSave}
-                    onCancel={() => { setIsEditing(false) }}
+                    onCancel={() => { setIsEditing(false); setShowDropdown(false); }}
                     type={type}
                 />
             ) : (

--- a/src/Kambaz/Courses/Piazza/ViewPost/Answer.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/Answer.tsx
@@ -1,6 +1,7 @@
 import { type Answer } from "../../../types";
 import WipAnswer from "./WipAnswer";
 import useAnswer from "../hooks/useAnswer";
+import ActionsDropdown from "./ActionsDropdown";
 
 interface AnswerProps {
     answerId: string;
@@ -50,34 +51,8 @@ export default function Answer(props: AnswerProps) {
                     <div className="content container-fluid">
                         <div className="g-0 row">
                             <div className="col">
-
-                                <div className="float-end dropdown">
-                                    {/* actions dropdown for edit and delete */}
-                                    <button
-                                        aria-haspopup="true"
-                                        aria-expanded={showDropdown}
-                                        data-id="postActionMenuId"
-                                        type="button"
-                                        className="dropdown-toggle btn btn-action"
-                                        onClick={() => setShowDropdown(!showDropdown)}
-                                    >Actions</button>
-                                    {showDropdown && (
-                                        <ul className="dropdown-menu show position-absolute">
-                                            <li>
-                                                <button className="dropdown-item" onClick={() => setIsEditing(true)}>
-                                                    Edit
-                                                </button>
-                                            </li>
-                                            <li>
-                                                <button className="dropdown-item text-danger"
-                                                onClick={handleDelete}
-                                                >
-                                                    Delete
-                                                </button>
-                                            </li>
-                                        </ul>
-                                    )}
-                                </div>
+                                {/* dropdown for editing and deleting */}
+                                <ActionsDropdown showDropdown={showDropdown} setShowDropdown={setShowDropdown} setIsEditing={setIsEditing} handleDelete={handleDelete} />
                                 <div className="py-3 history-selection">
                                     <div id="m7h0iykfwym12r_render" data-id="renderHtmlId" className="render-html-content overflow-hidden latex_process">{answer?.content}</div>
                                 </div>

--- a/src/Kambaz/Courses/Piazza/ViewPost/EditingAnswer.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/EditingAnswer.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import "./ViewPost.css";
 import EditorComponent from "./EditorComponent";
 
-interface WipAnswerProps {
+interface EditingAnswerProps {
     initialAnswer: string;
     onSave: (updatedAnswer: string, type: string) => void;
     onCancel: () => void;
@@ -11,7 +11,7 @@ interface WipAnswerProps {
 }
 
 // Component for rendering view for editing (updating or adding a new) answer.
-export default function WipAnswer(props: WipAnswerProps) {
+export default function EditingAnswer(props: EditingAnswerProps) {
 
     const { initialAnswer, onSave, onCancel, type } = props;
 

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/EditingResponse.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/EditingResponse.tsx
@@ -1,16 +1,16 @@
 
 import { useState } from "react";
 import "./../ViewPost.css";
-import EditorComponent from "./../EditorComponent";
+import EditorComponent from "../EditorComponent";
 
-interface WipFollowupDiscussionProps {
+interface EditingResponseProps {
     initialFud: string;
     onSave: (updatedFud: string) => void;
     onCancel: () => void;
 }
 
 // Component for rendering view for editing a followup discussion.
-export default function WipFollowupDiscussion(props: WipFollowupDiscussionProps) {
+export default function EditingResponse(props: EditingResponseProps) {
 
     const { initialFud, onSave, onCancel } = props;
 

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussion.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussion.tsx
@@ -4,15 +4,17 @@ import ResolvedButtons from "./ResolvedButtons/ResolvedButtons";
 import { type FollowupDiscussion } from "../../../../types";
 import EditorComponent from "../EditorComponent";
 import useFollowupDiscussion from "../../hooks/useFollowupDiscussion";
+import ActionsDropdown from "../ActionsDropdown";
 
 interface FollowupDiscussionProps {
     fudId: string;
+    setPost: (post: any) => void;
 }
 
 // Component for rendering an individual followup discussion.
 export default function FollowupDiscussion(props: FollowupDiscussionProps) {
 
-    const { fudId } = props;
+    const { fudId, setPost } = props;
 
     const {
         resolved,
@@ -25,11 +27,22 @@ export default function FollowupDiscussion(props: FollowupDiscussionProps) {
         replyContent,
         setReplyContent,
         handleSubmit,
-    } = useFollowupDiscussion(fudId);
+        showDropdown,
+        setShowDropdown,
+        handleDelete
+    } = useFollowupDiscussion(fudId, setPost);
 
     return (
         <div className="g-1 row">
-            <ResolvedButtons fudId={fudId} resolved={resolved} setResolved={setResolved} />
+            <div className="align-items-center row">
+            <div className="col-auto">
+                <ResolvedButtons fudId={fudId} resolved={resolved} setResolved={setResolved} />
+                </div>
+                <div className="col-auto ms-auto me-0">
+                {/* dropdown for editing and deleting */}
+                <ActionsDropdown showDropdown={showDropdown} setShowDropdown={setShowDropdown} setIsEditing={setIsReplying} handleDelete={handleDelete} />
+                </div>
+            </div>
             <div className="mx-0 col-auto">
                 <img className="avatar" width="30px" height="30px" aria-hidden="true" src="images/anonProfilePic.jpg" />
             </div>

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussion.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussion.tsx
@@ -23,6 +23,7 @@ export default function FollowupDiscussion(props: FollowupDiscussionProps) {
         author,
         formatDate,
         fud,
+        setFud,
         isReplying,
         setIsReplying,
         replyContent,
@@ -76,7 +77,7 @@ export default function FollowupDiscussion(props: FollowupDiscussionProps) {
                     )}
                 </div>
                 {/* loop through the replies list to render each reply */}
-                {fud?.replies.map((replyId => (<FollowupReply replyId={replyId} />)))}
+                {fud?.replies.map((replyId => (<FollowupReply replyId={replyId} setFud={setFud}/>)))}
 
                 <div className="gx-1 followup comment pr-0 pl-0 pb-0 row">
                     <div className="pr-0 mr-0 pl-0 pb-0 col">

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussion.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussion.tsx
@@ -5,7 +5,7 @@ import { type FollowupDiscussion } from "../../../../types";
 import EditorComponent from "../EditorComponent";
 import useFollowupDiscussion from "../../hooks/useFollowupDiscussion";
 import ActionsDropdown from "../ActionsDropdown";
-import WipFollowupDiscussion from "./WipFollowupDiscussion";
+import EditingResponse from "./EditingResponse";
 
 interface FollowupDiscussionProps {
     fudId: string;
@@ -66,7 +66,7 @@ export default function FollowupDiscussion(props: FollowupDiscussionProps) {
                 <div className="mb-2">
                     {/* if the user is editing the followup discussion, display a text editor; otherwise, display the fud content */}
                     {isEditing ? (
-                        <WipFollowupDiscussion initialFud={fud ? fud.content : ""} onSave={handleOnSave} onCancel={() => { setIsEditing(false); setShowDropdown(false); }} />
+                        <EditingResponse initialFud={fud ? fud.content : ""} onSave={handleOnSave} onCancel={() => { setIsEditing(false); setShowDropdown(false); }} />
                     ) : (
                         <div
                             id="m7mvt9ipcj61pk_render"

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussion.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussion.tsx
@@ -5,6 +5,7 @@ import { type FollowupDiscussion } from "../../../../types";
 import EditorComponent from "../EditorComponent";
 import useFollowupDiscussion from "../../hooks/useFollowupDiscussion";
 import ActionsDropdown from "../ActionsDropdown";
+import WipFollowupDiscussion from "./WipFollowupDiscussion";
 
 interface FollowupDiscussionProps {
     fudId: string;
@@ -29,18 +30,22 @@ export default function FollowupDiscussion(props: FollowupDiscussionProps) {
         handleSubmit,
         showDropdown,
         setShowDropdown,
-        handleDelete
+        handleDelete,
+        isEditing,
+        setIsEditing,
+        handleOnSave
     } = useFollowupDiscussion(fudId, setPost);
 
     return (
+
         <div className="g-1 row">
             <div className="align-items-center row">
-            <div className="col-auto">
-                <ResolvedButtons fudId={fudId} resolved={resolved} setResolved={setResolved} />
+                <div className="col-auto">
+                    <ResolvedButtons fudId={fudId} resolved={resolved} setResolved={setResolved} />
                 </div>
                 <div className="col-auto ms-auto me-0">
-                {/* dropdown for editing and deleting */}
-                <ActionsDropdown showDropdown={showDropdown} setShowDropdown={setShowDropdown} setIsEditing={setIsReplying} handleDelete={handleDelete} />
+                    {/* dropdown for editing and deleting */}
+                    <ActionsDropdown showDropdown={showDropdown} setShowDropdown={setShowDropdown} setIsEditing={setIsEditing} handleDelete={handleDelete} />
                 </div>
             </div>
             <div className="mx-0 col-auto">
@@ -57,11 +62,18 @@ export default function FollowupDiscussion(props: FollowupDiscussionProps) {
                         {formatDate(fud ? fud.datePosted : "")}
                     </time>
                 </span>
-                <div
-                    id="m7mvt9ipcj61pk_render"
-                    className="render-html-content overflow-hidden latex_process"
-                >
-                    {fud?.content}
+                <div className="mb-2">
+                    {/* if the user is editing the followup discussion, display a text editor; otherwise, display the fud content */}
+                    {isEditing ? (
+                        <WipFollowupDiscussion initialFud={fud ? fud.content : ""} onSave={handleOnSave} onCancel={() => { setIsEditing(false); setShowDropdown(false); }} />
+                    ) : (
+                        <div
+                            id="m7mvt9ipcj61pk_render"
+                            className="render-html-content overflow-hidden latex_process"
+                        >
+                            {fud?.content}
+                        </div>
+                    )}
                 </div>
                 {/* loop through the replies list to render each reply */}
                 {fud?.replies.map((replyId => (<FollowupReply replyId={replyId} />)))}

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussions.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupDiscussions.tsx
@@ -42,7 +42,7 @@ export default function FollowupDiscussions(props: FollowupDiscussionsProps) {
       {/* existing convo goes here */}
       {convoExists && (
         <div className="followup_content_wrapper col mx-3">
-          {fudIds.map((fudId) => (<FollowupDiscussion fudId={fudId} />))}
+          {fudIds.map((fudId) => (<FollowupDiscussion fudId={fudId} setPost={setPost} />))}
         </div>
       )}
 

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupReply.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupReply.tsx
@@ -1,6 +1,6 @@
 import { FollowupDiscussion } from "../../../../types";
 import ActionsDropdown from "../ActionsDropdown";
-import WipFollowupDiscussion from "./WipFollowupDiscussion";
+import EditingResponse from "./EditingResponse";
 import useFollowupReply from "../../hooks/useFollowupReply";
 
 interface FollowupReplyProps {
@@ -60,7 +60,7 @@ export default function FollowupReply(props: FollowupReplyProps) {
                 <div>
 
                     {isEditing ? (
-                        <WipFollowupDiscussion initialFud={reply ? reply.content : ""} onSave={handleOnSave} onCancel={() => { setIsEditing(false); setShowDropdown(false); }} />
+                        <EditingResponse initialFud={reply ? reply.content : ""} onSave={handleOnSave} onCancel={() => { setIsEditing(false); setShowDropdown(false); }} />
                     ) : (
 
                         <div

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupReply.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/FollowupReply.tsx
@@ -1,11 +1,7 @@
-import { useEffect, useState } from "react";
-import usePostSidebar from "../../hooks/usePostSidebar";
-import { FollowupDiscussion, Reply, User } from "../../../../types";
-import { deleteReply, getReplyById, updateReply } from "../../services/replyService";
-import { getUser } from "../../services/userService";
+import { FollowupDiscussion } from "../../../../types";
 import ActionsDropdown from "../ActionsDropdown";
-import { removeReplyFromFud } from "../../services/followupDiscussionService";
 import WipFollowupDiscussion from "./WipFollowupDiscussion";
+import useFollowupReply from "../../hooks/useFollowupReply";
 
 interface FollowupReplyProps {
     replyId: string;
@@ -17,113 +13,18 @@ export default function FollowupReply(props: FollowupReplyProps) {
 
     const { replyId, setFud } = props;
 
-    const { formatDate } = usePostSidebar();
-
-    // reply being rendered
-    const [reply, setReply] = useState<Reply | null>(null);
-
-    // author of the reply 
-    const [author, setAuthor] = useState<User | null>(null);
-
-    // variable for determining which icon to display alongside reply 
-    const [isStudent, setIsStudent] = useState<boolean>(false);
-
-    // keep track of if actions dropdown is showing 
-    const [showDropdown, setShowDropdown] = useState<boolean>(false);
-
-    // keep track of if the user is editing the reply
-    const [isEditing, setIsEditing] = useState<boolean>(false);
-
-    // handle deleting a reply
-    const handleDelete = async () => {
-        try {
-            if (reply) {
-                // delete from db
-                const deletedRes = await deleteReply(replyId);
-                if (deletedRes) {
-                    // remove from fud 
-                    const fudWithReplyDeleted = await removeReplyFromFud(reply?.followupDiscussionId, replyId);
-
-                    // set the post so the new answer component is displayed 
-                    if (fudWithReplyDeleted) {
-                        // TODO - maybe need to call setFud
-                        setFud(fudWithReplyDeleted);
-                    }
-                    else {
-                        throw new Error("Reply deletion unsuccessful");
-                    }
-                }
-
-            } else {
-                throw new Error("Cannot delete a reply that doesn't exist");
-            }
-        } catch (error) {
-            console.error("Error deleting reply:", error);
-        }
-    };
-
-    // handle saving a reply when it is being edited 
-    const handleOnSave = async (updatedContent: string) => {
-
-        try {
-            // convert HTML content from React Quill to plain text before saving in database 
-            const doc = new DOMParser().parseFromString(updatedContent, "text/html");
-            const plainTextContent = doc.body.textContent || "";
-
-            if (reply && reply._id) {
-                // update existing reply
-                const updatedReply = await updateReply(reply._id, plainTextContent);
-                setReply({ ...reply, content: updatedReply.content });
-            }
-            else {
-                throw new Error("Cannot update a reply that doesn't exist");
-            }
-        } catch (error) {
-            console.error("Error updating reply:", error);
-        }
-        setIsEditing(false);
-        setShowDropdown(false);
-    };
-
-
-    useEffect(() => {
-        /**
-         * Function to fetch the reply data based on the reply's ID.
-         */
-        const fetchData = async () => {
-            try {
-                const res = await getReplyById(replyId);
-                setReply(res || null);
-            } catch (error) {
-                // eslint-disable-next-line no-console
-                console.error('Error fetching reply:', error);
-            }
-        };
-
-        // eslint-disable-next-line no-console
-        fetchData().catch(e => console.log(e));
-    }, [replyId]);
-
-    useEffect(() => {
-        if (!reply?.authorId) return;
-
-        /**
-         * Function to fetch author data. 
-         */
-        const fetchAuthor = async () => {
-            try {
-                const fetchedAuthor = await getUser(reply.authorId);
-                if (fetchedAuthor) {
-                    setAuthor(fetchedAuthor);
-                    setIsStudent(fetchedAuthor.role === "STUDENT");
-                }
-            } catch (error) {
-                console.error("Error fetching author: ", error);
-            }
-        };
-
-        fetchAuthor();
-    }, [reply?.authorId]);
+    const { 
+        isStudent,
+        author,
+        formatDate,
+        reply,
+        showDropdown,
+        setShowDropdown,
+        isEditing,
+        setIsEditing,
+        handleOnSave,
+        handleDelete
+    } = useFollowupReply(replyId, setFud);
 
     return (
         <div

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/ResolvedButtons/ResolvedButtons.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/ResolvedButtons/ResolvedButtons.tsx
@@ -20,7 +20,7 @@ export default function ResolvedButtons(props: ResolvedButtonsProps) {
                     <input
                         // key added to force a re-render and show the radio button selection
                         key={String(resolved)}
-                        name="followup_resolution"
+                        name={`followup_resolution_${fudId}`}
                         type="radio"
                         className="custom-control-input"
                         checked={resolved}
@@ -36,7 +36,7 @@ export default function ResolvedButtons(props: ResolvedButtonsProps) {
                 <div className="custom-control custom-radio custom-control-inline">
                     <input
                         key={String(resolved)}
-                        name="followup_resolution"
+                        name={`followup_resolution_${fudId}`}
                         type="radio"
                         className="custom-control-input"
                         checked={!resolved}

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/WipFollowupDiscussion.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/WipFollowupDiscussion.tsx
@@ -19,11 +19,8 @@ export default function WipFollowupDiscussion(props: WipFollowupDiscussionProps)
 
     return (
         <article data-id="fud" className="answer" aria-label="Followup Discussion">
-
             <div className="content container-fluid">
-
                 <EditorComponent content={fudContent} setContent={setFudContent} />
-
             </div>
             {/* save and cancel buttons only appear when user is editing */}
             <footer className="border-top container-fluid">

--- a/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/WipFollowupDiscussion.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/FollowupDiscussions/WipFollowupDiscussion.tsx
@@ -1,0 +1,39 @@
+
+import { useState } from "react";
+import "./../ViewPost.css";
+import EditorComponent from "./../EditorComponent";
+
+interface WipFollowupDiscussionProps {
+    initialFud: string;
+    onSave: (updatedFud: string) => void;
+    onCancel: () => void;
+}
+
+// Component for rendering view for editing a followup discussion.
+export default function WipFollowupDiscussion(props: WipFollowupDiscussionProps) {
+
+    const { initialFud, onSave, onCancel } = props;
+
+    // variable to keep track of the answer's content
+    const [fudContent, setFudContent] = useState<string>(initialFud);
+
+    return (
+        <article data-id="fud" className="answer" aria-label="Followup Discussion">
+
+            <div className="content container-fluid">
+
+                <EditorComponent content={fudContent} setContent={setFudContent} />
+
+            </div>
+            {/* save and cancel buttons only appear when user is editing */}
+            <footer className="border-top container-fluid">
+                <div className="row">
+                    <div className="text-left align-self-center m-1 col-auto">
+                        <button className="btn btn-primary btn-sm me-2" onClick={() => onSave(fudContent)}>Submit</button>
+                        <button className="btn btn-secondary btn-sm" onClick={onCancel}>Cancel</button>
+                    </div>
+                </div>
+            </footer>
+        </article>
+    );
+};

--- a/src/Kambaz/Courses/Piazza/ViewPost/ViewPostPage/ViewPostPage.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/ViewPostPage/ViewPostPage.tsx
@@ -1,7 +1,7 @@
 import PostBox from "../PostBox";
 import FollowupDiscussions from "../FollowupDiscussions/FollowupDiscussions";
 import "./ViewPostPage.css";
-import WipAnswer from "../WipAnswer";
+import EditingAnswer from "../EditingAnswer";
 import ".././ViewPost.css";
 import NewAnswerInputBox from "../NewAnswerInputBox";
 import Answer from "../Answer";
@@ -43,7 +43,7 @@ const ViewPostPage = () => {
         ) : isWipStudentAnswer ? (
 
           // if a student answer is being created, render the wip display
-          <WipAnswer
+          <EditingAnswer
             initialAnswer=""
             onSave={handleOnSubmit}
             onCancel={() => {
@@ -67,7 +67,7 @@ const ViewPostPage = () => {
         ) : isWipInstructorAnswer ? (
 
           // if an instructor answer is being created, render the wip display 
-          <WipAnswer
+          <EditingAnswer
             initialAnswer=""
             onSave={handleOnSubmit}
             onCancel={() => {

--- a/src/Kambaz/Courses/Piazza/ViewPost/ViewPostPage/ViewPostPage.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/ViewPostPage/ViewPostPage.tsx
@@ -39,7 +39,7 @@ const ViewPostPage = () => {
       {post.type === 0 &&
         // if the post has a student answer, render the answer 
         (post.studentAnswer !== null ? (
-          <Answer answerId={post.studentAnswer} type={"student"} />
+          <Answer answerId={post.studentAnswer} type={"student"} setPost={setPost} />
         ) : isWipStudentAnswer ? (
 
           // if a student answer is being created, render the wip display
@@ -63,7 +63,7 @@ const ViewPostPage = () => {
 
         // if the post has an instructor answer, render it 
         (post.instructorAnswer !== null ? (
-          <Answer answerId={post.instructorAnswer} type={"instructor"} />
+          <Answer answerId={post.instructorAnswer} type={"instructor"} setPost={setPost} />
         ) : isWipInstructorAnswer ? (
 
           // if an instructor answer is being created, render the wip display 

--- a/src/Kambaz/Courses/Piazza/ViewPost/WipAnswer.tsx
+++ b/src/Kambaz/Courses/Piazza/ViewPost/WipAnswer.tsx
@@ -13,7 +13,7 @@ interface WipAnswerProps {
 // Component for rendering view for editing (updating or adding a new) answer.
 export default function WipAnswer(props: WipAnswerProps) {
 
-    const { initialAnswer, onSave, onCancel, type, } = props;
+    const { initialAnswer, onSave, onCancel, type } = props;
 
     // variable to keep track of the answer's content
     const [answerContent, setAnswerContent] = useState<string>(initialAnswer);

--- a/src/Kambaz/Courses/Piazza/hooks/useAnswer.tsx
+++ b/src/Kambaz/Courses/Piazza/hooks/useAnswer.tsx
@@ -11,7 +11,7 @@ const useAnswer = (answerId: string, type: string, setPost: (post: any) => void)
     // keep track of if the user is editing the answer 
     const [isEditing, setIsEditing] = useState<boolean>(false);
 
-    // keep track of if dropdown is showing 
+    // keep track of if actions dropdown is showing 
     const [showDropdown, setShowDropdown] = useState<boolean>(false);
 
     // author(s) of the answer 
@@ -53,9 +53,6 @@ const useAnswer = (answerId: string, type: string, setPost: (post: any) => void)
                 // delete from db
                 const deletedRes = await deleteAnswer(answerId);
                 if (deletedRes) {
-
-
-                    console.log("deleted res: ", deletedRes);
                     // remove from post 
                     const postWithAnswerDeleted = await removeAnswerFromPost(answer?.postId, answerId, type);
 

--- a/src/Kambaz/Courses/Piazza/hooks/useAnswer.tsx
+++ b/src/Kambaz/Courses/Piazza/hooks/useAnswer.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { Answer, User } from "../../../types";
-import { getAnswerById, updateAnswer } from "../services/answerService";
+import { deleteAnswer, getAnswerById, updateAnswer } from "../services/answerService";
 import { getUser } from "../services/userService";
+import { removeAnswerFromPost } from "../services/postService";
 
-const useAnswer = (answerId: string) => {
+const useAnswer = (answerId: string, type: string, setPost: (post: any) => void) => {
 
     const [answer, setAnswer] = useState<Answer | null>(null);
 
@@ -43,7 +44,36 @@ const useAnswer = (answerId: string) => {
             console.error("Error updating answer:", error);
         }
         setIsEditing(false);
-    }
+    };
+
+    const handleDelete = async () => {
+        try {
+            if (answer) {
+                // delete from db
+                const deletedRes = await deleteAnswer(answerId);
+                if (deletedRes) {
+
+
+                    console.log("deleted res: ", deletedRes);
+                    // remove from post 
+                    const postWithAnswerDeleted = await removeAnswerFromPost(answer?.postId, answerId, type);
+
+                    // set the post so the new answer component is displayed 
+                    if (postWithAnswerDeleted) {
+                        setPost(postWithAnswerDeleted);
+                    }
+                    else {
+                        throw new Error("Answer deletion unsuccessful");
+                    }
+                }
+
+            } else {
+                throw new Error("Cannot delete an answer that doesn't exist");
+            }
+        } catch (error) {
+            console.error("Error deleting answer:", error);
+        }
+    };
 
     useEffect(() => {
         /**
@@ -102,7 +132,8 @@ const useAnswer = (answerId: string) => {
         setShowDropdown,
         formatAnswerDate,
         authors,
-        setAuthors
+        setAuthors,
+        handleDelete
     }
 }
 

--- a/src/Kambaz/Courses/Piazza/hooks/useAnswer.tsx
+++ b/src/Kambaz/Courses/Piazza/hooks/useAnswer.tsx
@@ -47,6 +47,7 @@ const useAnswer = (answerId: string, type: string, setPost: (post: any) => void)
         setShowDropdown(false);
     };
 
+    // handle deleting answer
     const handleDelete = async () => {
         try {
             if (answer) {

--- a/src/Kambaz/Courses/Piazza/hooks/useAnswer.tsx
+++ b/src/Kambaz/Courses/Piazza/hooks/useAnswer.tsx
@@ -44,6 +44,7 @@ const useAnswer = (answerId: string, type: string, setPost: (post: any) => void)
             console.error("Error updating answer:", error);
         }
         setIsEditing(false);
+        setShowDropdown(false);
     };
 
     const handleDelete = async () => {

--- a/src/Kambaz/Courses/Piazza/hooks/useFollowupDiscussion.tsx
+++ b/src/Kambaz/Courses/Piazza/hooks/useFollowupDiscussion.tsx
@@ -102,20 +102,20 @@ const useFollowupDiscussion = (fudId: string, setPost: (post: any) => void) => {
                     // remove from post 
                     const postWithFudDeleted = await removeFudFromPost(fud?.postId, fudId);
 
-                    // set the post so the new answer component is displayed 
+                    // set the post so the new fud component is displayed 
                     if (postWithFudDeleted) {
                         setPost(postWithFudDeleted);
                     }
                     else {
-                        throw new Error("Answer deletion unsuccessful");
+                        throw new Error("Fud deletion unsuccessful");
                     }
                 }
 
             } else {
-                throw new Error("Cannot delete an answer that doesn't exist");
+                throw new Error("Cannot delete a fud that doesn't exist");
             }
         } catch (error) {
-            console.error("Error deleting answer:", error);
+            console.error("Error deleting fud:", error);
         }
     };
 
@@ -166,6 +166,7 @@ const useFollowupDiscussion = (fudId: string, setPost: (post: any) => void) => {
         author,
         formatDate,
         fud,
+        setFud,
         isReplying,
         setIsReplying,
         replyContent,

--- a/src/Kambaz/Courses/Piazza/hooks/useFollowupReply.tsx
+++ b/src/Kambaz/Courses/Piazza/hooks/useFollowupReply.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+import { deleteReply, getReplyById, updateReply } from "../services/replyService";
+import { getUser } from "../services/userService";
+import { removeReplyFromFud } from "../services/followupDiscussionService";
+import usePostSidebar from "./usePostSidebar";
+import { FollowupDiscussion, Reply, User } from "../../../types";
+
+const useFollowupReply = (replyId: string, setFud: (fud: FollowupDiscussion) => void) => {
+    
+    const { formatDate } = usePostSidebar();
+
+    // reply being rendered
+    const [reply, setReply] = useState<Reply | null>(null);
+
+    // author of the reply 
+    const [author, setAuthor] = useState<User | null>(null);
+
+    // variable for determining which icon to display alongside reply 
+    const [isStudent, setIsStudent] = useState<boolean>(false);
+
+    // keep track of if actions dropdown is showing 
+    const [showDropdown, setShowDropdown] = useState<boolean>(false);
+
+    // keep track of if the user is editing the reply
+    const [isEditing, setIsEditing] = useState<boolean>(false);
+
+    // handle deleting a reply
+    const handleDelete = async () => {
+        try {
+            if (reply) {
+                // delete from db
+                const deletedRes = await deleteReply(replyId);
+                if (deletedRes) {
+                    // remove from fud 
+                    const fudWithReplyDeleted = await removeReplyFromFud(reply?.followupDiscussionId, replyId);
+
+                    // set the post so the new answer component is displayed 
+                    if (fudWithReplyDeleted) {
+                        setFud(fudWithReplyDeleted);
+                    }
+                    else {
+                        throw new Error("Reply deletion unsuccessful");
+                    }
+                }
+
+            } else {
+                throw new Error("Cannot delete a reply that doesn't exist");
+            }
+        } catch (error) {
+            console.error("Error deleting reply:", error);
+        }
+    };
+
+    // handle saving a reply when it is being edited 
+    const handleOnSave = async (updatedContent: string) => {
+
+        try {
+            // convert HTML content from React Quill to plain text before saving in database 
+            const doc = new DOMParser().parseFromString(updatedContent, "text/html");
+            const plainTextContent = doc.body.textContent || "";
+
+            if (reply && reply._id) {
+                // update existing reply
+                const updatedReply = await updateReply(reply._id, plainTextContent);
+                setReply({ ...reply, content: updatedReply.content });
+            }
+            else {
+                throw new Error("Cannot update a reply that doesn't exist");
+            }
+        } catch (error) {
+            console.error("Error updating reply:", error);
+        }
+        setIsEditing(false);
+        setShowDropdown(false);
+    };
+
+
+    useEffect(() => {
+        /**
+         * Function to fetch the reply data based on the reply's ID.
+         */
+        const fetchData = async () => {
+            try {
+                const res = await getReplyById(replyId);
+                setReply(res || null);
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error('Error fetching reply:', error);
+            }
+        };
+
+        // eslint-disable-next-line no-console
+        fetchData().catch(e => console.log(e));
+    }, [replyId]);
+
+    useEffect(() => {
+        if (!reply?.authorId) return;
+
+        /**
+         * Function to fetch author data. 
+         */
+        const fetchAuthor = async () => {
+            try {
+                const fetchedAuthor = await getUser(reply.authorId);
+                if (fetchedAuthor) {
+                    setAuthor(fetchedAuthor);
+                    setIsStudent(fetchedAuthor.role === "STUDENT");
+                }
+            } catch (error) {
+                console.error("Error fetching author: ", error);
+            }
+        };
+
+        fetchAuthor();
+    }, [reply?.authorId]);
+
+    return {
+        isStudent,
+        author,
+        formatDate,
+        reply,
+        showDropdown,
+        setShowDropdown,
+        isEditing,
+        setIsEditing,
+        handleOnSave,
+        handleDelete
+    }
+}
+
+export default useFollowupReply;

--- a/src/Kambaz/Courses/Piazza/hooks/usePostSidebar.tsx
+++ b/src/Kambaz/Courses/Piazza/hooks/usePostSidebar.tsx
@@ -19,11 +19,6 @@ const usePostSidebar = () => {
     navigate(`/Kambaz/Courses/${cid}/Piazza/NewPostPage`);
   }
 
-  // const [posts, setPosts] = useState<Post[]>([]);
-
-  // fetch posts  
-  
-
   useEffect(() => {
     // eslint-disable-next-line no-console
     fetchPosts().catch(e => console.log(e));

--- a/src/Kambaz/Courses/Piazza/hooks/useViewPostPage.tsx
+++ b/src/Kambaz/Courses/Piazza/hooks/useViewPostPage.tsx
@@ -54,7 +54,7 @@ const useViewPostPage = () => {
             }
 
             catch (error) {
-                console.error("Error updating answer:", error);
+                console.error("Error creating answer:", error);
             }
         }
     }

--- a/src/Kambaz/Courses/Piazza/services/answerService.ts
+++ b/src/Kambaz/Courses/Piazza/services/answerService.ts
@@ -52,4 +52,18 @@ const createAnswer = async (newAnswer: Answer): Promise<Answer> => {
   return res.data;
 };
 
-export { getAnswerById, updateAnswer, createAnswer };
+/**
+ * Deletes an answer.
+ * @param aid The id of the answer to delete.
+ * @returns boolean indicating the success of the deletion.
+ */
+const deleteAnswer = async (aid: string): Promise<boolean> => {
+  const res = await api.delete(`${ANSWER_API_URL}/${aid}`);
+
+  if (res.status !== 200) {
+    throw new Error("Error while deleting answer");
+  }
+  return res.data;
+};
+
+export { getAnswerById, updateAnswer, createAnswer, deleteAnswer };

--- a/src/Kambaz/Courses/Piazza/services/followupDiscussionService.ts
+++ b/src/Kambaz/Courses/Piazza/services/followupDiscussionService.ts
@@ -103,10 +103,25 @@ const markDiscussionUnresolved = async (
   return res.data;
 };
 
+/**
+ * Deletes a followup discussion.
+ * @param fudId The id of the followup discussion to delete.
+ * @returns boolean indicating the success of the deletion.
+ */
+const deleteFollowupDiscussion = async (fudId: string): Promise<boolean> => {
+  const res = await api.delete(`${FOLLOWUP_DISCUSSION_API_URL}/${fudId}`);
+
+  if (res.status !== 200) {
+    throw new Error("Error while deleting followup discussion");
+  }
+  return res.data; 
+};
+
 export {
   getFollowupDiscussionById,
   createDiscussion,
   addReplyToDiscussion,
   markDiscussionResolved,
   markDiscussionUnresolved,
+  deleteFollowupDiscussion
 };

--- a/src/Kambaz/Courses/Piazza/services/followupDiscussionService.ts
+++ b/src/Kambaz/Courses/Piazza/services/followupDiscussionService.ts
@@ -137,6 +137,22 @@ const updateFud = async (
   return res.data;
 };
 
+/**
+ * Removes a reply from a followup discussion's array of reply ids.
+ * @param fudId The id of the followup discussion from which to remove the reply.
+ * @param replyId The id of the reoly to remove.
+ * @returns The updated followup discussion object with the reply id removed from the array.
+ */
+const removeReplyFromFud = async (fudId: string, replyId: string): Promise<FollowupDiscussion> => {
+  const data = { fudId, replyId }; 
+  const res = await api.put(`${FOLLOWUP_DISCUSSION_API_URL}/removeReply`, data);
+
+  if (res.status !== 200) {
+    throw new Error("Error while removing reply from fud");
+  }
+  return res.data;
+}
+
 export {
   getFollowupDiscussionById,
   createDiscussion,
@@ -145,4 +161,5 @@ export {
   markDiscussionUnresolved,
   deleteFollowupDiscussion,
   updateFud,
+  removeReplyFromFud
 };

--- a/src/Kambaz/Courses/Piazza/services/followupDiscussionService.ts
+++ b/src/Kambaz/Courses/Piazza/services/followupDiscussionService.ts
@@ -114,7 +114,27 @@ const deleteFollowupDiscussion = async (fudId: string): Promise<boolean> => {
   if (res.status !== 200) {
     throw new Error("Error while deleting followup discussion");
   }
-  return res.data; 
+  return res.data;
+};
+
+/**
+ * Updates a followup discussion upon a user editing its content.
+ *
+ * @param fudId The id of the fud being updated.
+ * @param newContent The updated content of the fud.
+ * @returns The updated fud object.
+ */
+const updateFud = async (
+  fudId: string,
+  newContent: string
+): Promise<FollowupDiscussion> => {
+  const data = { fudId, newContent };
+  const res = await api.put(`${FOLLOWUP_DISCUSSION_API_URL}/updateFud`, data);
+
+  if (res.status !== 200) {
+    throw new Error("Error while updating fud");
+  }
+  return res.data;
 };
 
 export {
@@ -123,5 +143,6 @@ export {
   addReplyToDiscussion,
   markDiscussionResolved,
   markDiscussionUnresolved,
-  deleteFollowupDiscussion
+  deleteFollowupDiscussion,
+  updateFud,
 };

--- a/src/Kambaz/Courses/Piazza/services/postService.ts
+++ b/src/Kambaz/Courses/Piazza/services/postService.ts
@@ -74,4 +74,24 @@ const addAnswerToPost = async (
   return res.data;
 };
 
-export { getPostById, getPosts, addDiscussionToPost, addAnswerToPost };
+const removeAnswerFromPost = async (
+  pid: string,
+  aid: string,
+  type: string
+): Promise<Post> => {
+  const data = { pid, aid, type };
+  const res = await api.put(`${POST_API_URL}/removeAnswer`, data);
+
+  if (res.status !== 200) {
+    throw new Error("Error while removing answer from post");
+  }
+  return res.data;
+};
+
+export {
+  getPostById,
+  getPosts,
+  addDiscussionToPost,
+  addAnswerToPost,
+  removeAnswerFromPost,
+};

--- a/src/Kambaz/Courses/Piazza/services/postService.ts
+++ b/src/Kambaz/Courses/Piazza/services/postService.ts
@@ -111,6 +111,21 @@ const removeFudFromPost = async (pid: string, fudId: string): Promise<Post> => {
   return res.data;
 };
 
+/**
+ * Adds a new post to the database.
+ *
+ * @param newPost The new post object being created.
+ * @returns The new post object.
+ */
+const createPost = async (newPost: Post): Promise<Post> => {
+  const res = await api.post(`${POST_API_URL}/createPost`, newPost);
+
+  if (res.status !== 200) {
+    throw new Error("Error while creating post");
+  }
+  return res.data;
+};
+
 export {
   getPostById,
   getPosts,
@@ -118,4 +133,5 @@ export {
   addAnswerToPost,
   removeAnswerFromPost,
   removeFudFromPost,
+  createPost,
 };

--- a/src/Kambaz/Courses/Piazza/services/postService.ts
+++ b/src/Kambaz/Courses/Piazza/services/postService.ts
@@ -74,6 +74,13 @@ const addAnswerToPost = async (
   return res.data;
 };
 
+/**
+ * Removes an answer (sets the answer field value to null) from a post following the answer's deletion.
+ * @param pid The id of the post from which to remove the answer.
+ * @param aid The id of the answer being removed.
+ * @param type The type of post (student or instructor);
+ * @returns The post object with the answer removed.
+ */
 const removeAnswerFromPost = async (
   pid: string,
   aid: string,
@@ -88,10 +95,27 @@ const removeAnswerFromPost = async (
   return res.data;
 };
 
+/**
+ * Removes a followup discussion from a post's array of fuds.
+ * @param pid The id of the post from which to remove the fud.
+ * @param fudId The id of the fud to remove.
+ * @returns The updated post object with the fud removed from the array.
+ */
+const removeFudFromPost = async (pid: string, fudId: string): Promise<Post> => {
+  const data = { pid, fudId };
+  const res = await api.put(`${POST_API_URL}/removeFud`, data);
+
+  if (res.status !== 200) {
+    throw new Error("Error while removing fud from post");
+  }
+  return res.data;
+};
+
 export {
   getPostById,
   getPosts,
   addDiscussionToPost,
   addAnswerToPost,
   removeAnswerFromPost,
+  removeFudFromPost,
 };

--- a/src/Kambaz/Courses/Piazza/services/replyService.ts
+++ b/src/Kambaz/Courses/Piazza/services/replyService.ts
@@ -32,4 +32,18 @@ const createReply = async (newReply: Reply): Promise<Reply> => {
   return res.data;
 };
 
-export { getReplyById, createReply };
+/**
+ * Deletes a reply.
+ * @param aid The id of the reply to delete.
+ * @returns boolean indicating the success of the deletion.
+ */
+const deleteReply = async (rid: string): Promise<boolean> => {
+  const res = await api.delete(`${REPLY_API_URL}/${rid}`);
+
+  if (res.status !== 200) {
+    throw new Error("Error while deleting reply");
+  }
+  return res.data;
+};
+
+export { getReplyById, createReply, deleteReply };

--- a/src/Kambaz/Courses/Piazza/services/replyService.ts
+++ b/src/Kambaz/Courses/Piazza/services/replyService.ts
@@ -46,4 +46,21 @@ const deleteReply = async (rid: string): Promise<boolean> => {
   return res.data;
 };
 
-export { getReplyById, createReply, deleteReply };
+/**
+ * Updates a reply upon a user editing its content.
+ *
+ * @param rid The id of the reply being updated.
+ * @param newContent The updated content of the answer.
+ * @returns The updated answer object.
+ */
+const updateReply = async (rid: string, newContent: string): Promise<Reply> => {
+  const data = { rid, newContent };
+  const res = await api.put(`${REPLY_API_URL}/updateReply`, data);
+
+  if (res.status !== 200) {
+    throw new Error("Error while updating reply");
+  }
+  return res.data;
+};
+
+export { getReplyById, createReply, deleteReply, updateReply };

--- a/src/Kambaz/types.tsx
+++ b/src/Kambaz/types.tsx
@@ -1,6 +1,6 @@
 export interface Post {
     _id?: string; // MongoDB ObjectId stored as a string
-    folderId: string;
+    folders: string[];
     authorId: string;
     datePosted: string;
     type: number;


### PR DESCRIPTION
**Description:**
This PR contains the following work: 
- edit Answer 
- delete Answer 
- edit Followup Discussion 
- delete Followup Discussion 
- edit Reply
- delete Reply 
- "Actions" dropdown for Answer, Followup Discussion, and Reply 
- updated the `Post` type to have folders be a list of strings 
- updated the New Post endpoint to more closely align with format of our other endpoints and reflect the folders attribute type change 

Next Steps: 
- edit and delete endpoints for Post 
- "Actions" dropdown for post 
- routing so that only instructors and original poster can edit things 
- fix the sixing of the "Actions" dropdown