### PR TITLE
Manage Class Final

### DIFF
--- a/src/Kambaz/Courses/Piazza/ManageClass/FolderSelector.tsx
+++ b/src/Kambaz/Courses/Piazza/ManageClass/FolderSelector.tsx
@@ -2,15 +2,20 @@ import { FaPencil } from "react-icons/fa6";
 import { Form } from "react-bootstrap";
 import { useState } from "react";
 import { FaBars, FaSave, FaTrash } from "react-icons/fa";
-import useFolders from "../hooks/useFolders";
+import { Folder } from "../../../types";
 
 interface Props {
   name: string;
 }
 
-export default function FolderSelector() {
+interface OuterProps {
+  folders: Folder[];
+  handleDeleteFolders: (folders: string[]) => void;
+  handleEditFolder: (oldName: string, newName: string) => void;
+}
+
+export default function FolderSelector({ folders, handleDeleteFolders, handleEditFolder }: OuterProps) {
   const [selectedFolders, setSelectedFolders] = useState<string[]>([]);
-  const { folders, deleteFoldersHook, editFolderName } = useFolders();
 
   const Folder = ({ name }: Props) => {
     const [editing, setEditing] = useState(false);
@@ -18,7 +23,7 @@ export default function FolderSelector() {
     const editFolderOnClick = () => {
       if (editing) {
         // if we are currently editing, then we save the new folder name
-        editFolderName(name, editedName);
+        handleEditFolder(name, editedName);
       }
       // flip the editing state
       setEditing(!(editing));
@@ -78,7 +83,8 @@ export default function FolderSelector() {
       <div className="d-flex">
         <button className="manage_folders_button" disabled={selectedFolders.length === 0}
           onClick={() => {
-            deleteFoldersHook(selectedFolders);
+            handleDeleteFolders(selectedFolders);
+            setSelectedFolders([]);
           }}>
           <FaTrash />
           Delete selected folders

--- a/src/Kambaz/Courses/Piazza/ManageClass/ManageFolders.tsx
+++ b/src/Kambaz/Courses/Piazza/ManageClass/ManageFolders.tsx
@@ -3,8 +3,13 @@ import FolderSelector from "./FolderSelector";
 import useFolders from "../hooks/useFolders";
 
 export default function ManageFolders() {
-  const [folderName, setFolderName] = useState<string>("");
-  const { addFolder } = useFolders();
+  const [newFolderName, setNewFolderName] = useState<string>("");
+  const { folders, handleAddFolder, handleDeleteFolder, handleEditFolder } = useFolders();
+
+  const addFolderClearInputField = () => {
+    handleAddFolder(newFolderName);
+    setNewFolderName("");
+  }
 
   return (
     <div id="manage_box" className="d-flex flex-column gap-3">
@@ -22,14 +27,14 @@ export default function ManageFolders() {
         <h3 className="fw-bold">Create new folders:</h3>
         <p>Add folders that are relevant for your class.</p>
         <div className="d-flex flex-row justify-content-between">
-          <input className="w-auto" placeholder="Add a folder(s)" onChange={(e) => setFolderName(e.target.value)} />
-          <button className="blue_button" onClick={() => addFolder(folderName)}>Add folder</button>
+          <input className="w-auto" placeholder="Add a folder(s)" value={newFolderName} onChange={(e) => setNewFolderName(e.target.value)} />
+          <button className="blue_button" onClick={addFolderClearInputField}>Add folder</button>
         </div>
       </div>
 
       {/* Manage folders */}
       <div className="d-flex flex-column">
-        <FolderSelector />
+        <FolderSelector folders={folders} handleDeleteFolders={handleDeleteFolder} handleEditFolder={handleEditFolder} />
       </div>
     </div>
   )

--- a/src/Kambaz/Courses/Piazza/hooks/useFolders.tsx
+++ b/src/Kambaz/Courses/Piazza/hooks/useFolders.tsx
@@ -36,6 +36,13 @@ const useFolders = () => {
     }
   }
 
+  const handleAddFolder = async (folderName: string) => {
+    const f = await addFolder(folderName);
+    if (!f) {
+      console.error("Could not add new folder");
+    }
+  }
+
   const deleteFoldersHook = async (folders: string[]) => {
     try {
       const normalised = folders.map((f) => ({ cid: cid ?? "", name: f }));
@@ -44,6 +51,13 @@ const useFolders = () => {
       return resp;
     } catch (err) {
       console.error(`Error in use-hook while deleting folder: ${err}`);
+    }
+  }
+
+  const handleDeleteFolder = async (folderNames: string[]) => {
+    const f = await deleteFoldersHook(folderNames);
+    if (!f) {
+      console.error("Could not delete folders");
     }
   }
 
@@ -57,12 +71,19 @@ const useFolders = () => {
     }
   }
 
+  const handleEditFolder = async (oldName: string, newName: string) => {
+    const f = await editFolderName(oldName, newName);
+    if (!f) {
+      console.error("Error when editing folder");
+    }
+  }
+
   return {
     folders,
     fetchPostsInFolder,
-    addFolder,
-    deleteFoldersHook,
-    editFolderName,
+    handleAddFolder,
+    handleDeleteFolder,
+    handleEditFolder,
   };
 }
 

--- a/src/Kambaz/Courses/Piazza/index.tsx
+++ b/src/Kambaz/Courses/Piazza/index.tsx
@@ -21,12 +21,21 @@ const SideBar = () => {
 
 }
 
+const FolderNav = () => {
+  const location = useLocation();
+  if (location.pathname.includes("Manage-Class")
+    || location.pathname.includes("manage-class")) {
+    return <></>;
+  }
+  return <HwFolderNav />;
+}
+
 export default function Piazza() {
   return (
     <div>
       <PostSidebarProvider>
         <PiazzaNavBarTop />
-        <HwFolderNav />
+        <FolderNav />
 
         <div className="wd-layout">
           <SideBar />


### PR DESCRIPTION
This PR has the much-awaited improvements for Manage Class:

- data persistence!! adding, editing, deleting folders reflects in the UI immediately
- hiding the folder nav bar on the manage class page because 1. it's what happens in real Piazza 2. it's so much easier not worrying about keeping the folder names consistent with each edit

Something to think about: 

- do we want to enforce that folder names are unique in the database? for example: if we have `hw4` and `hw6` in the list, what happens when we rename `hw4` to `hw6`?